### PR TITLE
Add workspace setting

### DIFF
--- a/hyped.code-workspace
+++ b/hyped.code-workspace
@@ -1,0 +1,37 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "editor.rulers": [100],
+    "editor.renderWhitespace": "all",
+    "files.trimTrailingWhitespace": true,
+    "editor.tabSize": 2,
+    "files.eol": "\n",
+    "files.autoSave": "onWindowChange",
+    "files.exclude": {
+      "**/.cpplint-cache": true,
+      "bin": true,
+      "**/build": true,
+      "**/*.a": true,
+      "**/testrunner*": true,
+      "hyped*": true
+    },
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "C_Cpp.clang_format_style": "Google",
+    "C_Cpp.default.includePath": [
+      "${workspaceRoot}/src",
+      "${workspaceRoot}/lib",
+      "${workspaceRoot}/test/lib/googletest/googletest/include"
+    ],
+    "C_Cpp.default.defines": [
+
+    ],
+    "editor.detectIndentation": false,
+    "C_Cpp.default.cppStandard": "c++11",
+    "C_Cpp.default.cStandard": "c11"
+  }
+}


### PR DESCRIPTION
This is to provide common configuration of our workspace for all VSC users. It controls some VSC settings, e.g. indentation, line ending. Furthermore, it tells VSC where to look for included headers, i.e. pointing to our libraries.
This PR corresponds to this [clickup task](https://app.clickup.com/t/1ye6t1).
