### PR TITLE
Fix linter errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os: osx
 before_install:
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"
-script: "make testrunner"
+script: "make testrunner lintall"
 rvm:
   - 9.00
-  

--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,12 @@ ifeq ($(NOLINT), 0)
 endif
 
 lintall:
-	$(Echo) "Linting /src\n"
+	$(Echo) "Linting src/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=src
-	$(Echo) "\nLinting /run\n"
+	$(Echo) "Linting run/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=run
-	$(Echo) "\nLinting /test\n"
-	$(Verb) $(MAKE) -C test lint
+	$(Echo) "Linting test/"
+	$(Verb) $(MAKE) -C test lint --no-print-directory
 
 testrunner: test/lib/libtest.a
 	$(VERB) $(MAKE) -C test
@@ -106,6 +106,7 @@ clean:
 
 cleanlint:
 	$(Verb) rm -f .cpplint-cache
+	$(Verb) $(MAKE) -C test cleanlint --no-print-directory
 
 define echo_var
 	@echo $(1) = $($1)

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ ifeq ($(NOLINT), 0)
 endif
 
 lintall:
-	$(Echo) "Linting src/"
+	$(Echo) "\nLinting src/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=src
-	$(Echo) "Linting run/"
+	$(Echo) "\nLinting run/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=run
-	$(Echo) "Linting test/"
+	$(Echo) "\nLinting test/"
 	$(Verb) $(MAKE) -C test lint --no-print-directory
 
 testrunner: test/lib/libtest.a

--- a/src/Lint_IGNORE_DIRS.files
+++ b/src/Lint_IGNORE_DIRS.files
@@ -1,2 +1,1 @@
 telemetrydata
-embrakes

--- a/src/embrakes/main.cpp
+++ b/src/embrakes/main.cpp
@@ -19,18 +19,15 @@
 #include "main.hpp"
 #include "utils/config.hpp"
 
-namespace hyped
-{
+namespace hyped {
+namespace embrakes {
 
-namespace embrakes
-{
 Main::Main(uint8_t id, Logger &log)
   : Thread(id, log),
     log_(log),
     data_(data::Data::getInstance()),
     sys_(utils::System::getSystem())
 {
-
   // parse GPIO pins from config.txt file
   for (int i = 0; i < 4; i++) {
     command_pins_[i] = sys_.config->embrakes.command[i];
@@ -40,10 +37,10 @@ Main::Main(uint8_t id, Logger &log)
   // Stepper brake_2(command_pins_[1], button_pins_[1], log_, 2);
   // Stepper brake_3(command_pins_[2], button_pins_[2], log_, 3);
   // Stepper brake_4(command_pins_[3], button_pins_[3], log_, 4);
-
 }
 
-void Main::run() {
+void Main::run()
+{
   log_.INFO("Brakes", "Thread started");
 
   System &sys = System::getSystem();
@@ -53,12 +50,12 @@ void Main::run() {
     em_brakes_ = data_.getEmergencyBrakesData();
     sm_data_ = data_.getStateMachineData();
     tlm_data_ = data_.getTelemetryData();
-    
+
     switch (sm_data_.current_state) {
       case data::State::kIdle:
-        if(!tlm_data_.nominal_braking_command) {
+        if (!tlm_data_.nominal_braking_command) {
           log_.INFO("Brakes", "RETRACT COMMAND");
-          if(brake_1->checkClamped()){
+          if (brake_1->checkClamped()) {
             brake_1->sendRetract();
           }
           // if(brake_2->checkClamped()){
@@ -76,9 +73,9 @@ void Main::run() {
           // brake_3->checkHome();
           // brake_4->checkHome();
 
-        } else if(tlm_data_.nominal_braking_command) {
+        } else if (tlm_data_.nominal_braking_command) {
           log_.INFO("Brakes", "ENGAGE COMMAND");
-          if(!brake_1->checkClamped()){
+          if (!brake_1->checkClamped()) {
             brake_1->sendClamp();
           }
           // if(!brake_2->checkClamped()){
@@ -95,11 +92,10 @@ void Main::run() {
           // brake_2->checkHome();
           // brake_3->checkHome();
           // brake_4->checkHome();
-
         }
         break;
       case data::State::kCalibrating:
-        if(brake_1->checkClamped()){
+        if (brake_1->checkClamped()) {
           brake_1->sendRetract();
         }
         // if(brake_2->checkClamped()){
@@ -111,7 +107,7 @@ void Main::run() {
         // if(brake_4->checkClamped()){
         //   brake_4->sendRetract();
         // }
-        if(!brake_1->checkClamped()) {
+        if (!brake_1->checkClamped()) {
           em_brakes_.module_status = ModuleStatus::kReady;
           data_.setEmergencyBrakesData(em_brakes_);
         }
@@ -128,7 +124,7 @@ void Main::run() {
         // brake_4->checkAccFailure();
         break;
       case data::State::kNominalBraking:
-        if (!brake_1->checkClamped()){
+        if (!brake_1->checkClamped()) {
           brake_1->sendClamp();
         }
         // if(!brake_2->checkClamped()){
@@ -152,9 +148,8 @@ void Main::run() {
         // brake_4->checkBrakingFailure();
         break;
       case data::State::kFinished:
-        if(tlm_data_.nominal_braking_command) {
-          
-          if(brake_1->checkClamped()){
+        if (tlm_data_.nominal_braking_command) {
+          if (brake_1->checkClamped()) {
             brake_1->sendRetract();
           }
           // if(brake_2->checkClamped()){
@@ -171,10 +166,8 @@ void Main::run() {
           // brake_2->checkHome();
           // brake_3->checkHome();
           // brake_4->checkHome();
-
-        } else if(!tlm_data_.nominal_braking_command) {
-
-          if(!brake_1->checkClamped()){
+        } else if (!tlm_data_.nominal_braking_command) {
+          if (!brake_1->checkClamped()) {
             brake_1->sendClamp();
           }
           // if(!brake_2->checkClamped()){
@@ -191,7 +184,6 @@ void Main::run() {
           // brake_2->checkHome();
           // brake_3->checkHome();
           // brake_4->checkHome();
-
         }
         break;
       default:
@@ -200,5 +192,6 @@ void Main::run() {
   }
   log_.INFO("Brakes", "Thread shutting down");
 }
+
 }  // namespace embrakes
 }  // namespace hyped

--- a/src/embrakes/main.hpp
+++ b/src/embrakes/main.hpp
@@ -35,9 +35,9 @@ using data::ModuleStatus;
 
 namespace embrakes {
 /*
- * @description This module handles the interaction with the embrakes. 
+ * @description This module handles the interaction with the embrakes.
 */
-class Main : public Thread 
+class Main : public Thread
 {
   public:
     /*

--- a/src/embrakes/stepper.cpp
+++ b/src/embrakes/stepper.cpp
@@ -34,55 +34,61 @@ Stepper::Stepper(uint8_t enable_pin, uint8_t button_pin, Logger& log, uint8_t id
   GPIO button_(button_pin, utils::io::gpio::kIn, log_);
 }
 
-void Stepper::checkHome() {
-  if(button_.read() && !em_brakes_data_.brakes_retracted[brake_id_-1]){
+void Stepper::checkHome()
+{
+  if (button_.read() && !em_brakes_data_.brakes_retracted[brake_id_-1]) {
     em_brakes_data_.brakes_retracted[brake_id_-1] = true;
     data_.setEmergencyBrakesData(em_brakes_data_);
-  } else if(!button_.read() && em_brakes_data_.brakes_retracted[brake_id_-1]){
+  } else if (!button_.read() && em_brakes_data_.brakes_retracted[brake_id_-1]) {
     em_brakes_data_.brakes_retracted[brake_id_-1] = false;
     data_.setEmergencyBrakesData(em_brakes_data_);
   }
 }
 
-void Stepper::sendRetract() {
+void Stepper::sendRetract()
+{
   log_.INFO("Brakes", "Sending a retract message to brake %i", brake_id_);
   command_pin_.clear();
   is_clamped_ = false;
 }
 
-void Stepper::sendClamp() {
+void Stepper::sendClamp()
+{
   log_.INFO("Brakes", "Sending a retract message to brake %i", brake_id_);
   command_pin_.set();
   is_clamped_ = true;
 }
 
-void Stepper::checkAccFailure() {
-  if(!button_.read()){
+void Stepper::checkAccFailure()
+{
+  if (!button_.read()) {
     timer = utils::Timer::getTimeMicros();
-    if((utils::Timer::getTimeMicros() - timer > 200000) && !button_.read()){
+    if ((utils::Timer::getTimeMicros() - timer > 200000) && !button_.read()) {
       log_.ERR("Brakes", "Brake %b failure", brake_id_);
       em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
       data_.setEmergencyBrakesData(em_brakes_data_);
-    } else{
+    } else {
       return;
     }
   }
 }
 
-void Stepper::checkBrakingFailure() {
-  if(button_.read()){
+void Stepper::checkBrakingFailure()
+{
+  if (button_.read()) {
     timer = utils::Timer::getTimeMicros();
-    if((utils::Timer::getTimeMicros() - timer > 200000) && button_.read()){
+    if ((utils::Timer::getTimeMicros() - timer > 200000) && button_.read()) {
       log_.ERR("Brakes", "Brake %b failure", brake_id_);
       em_brakes_data_.module_status = ModuleStatus::kCriticalFailure;
       data_.setEmergencyBrakesData(em_brakes_data_);
-    } else{
+    } else {
       return;
     }
   }
 }
 
-bool Stepper::checkClamped() {
+bool Stepper::checkClamped()
+{
   return is_clamped_;
 }
 

--- a/src/embrakes/stepper.hpp
+++ b/src/embrakes/stepper.hpp
@@ -36,7 +36,7 @@ using data::ModuleStatus;
 namespace embrakes {
 
 class Stepper {
-  public:
+ public:
   /**
    * @brief Construct a new Stepper object
    * @param log, node id
@@ -67,17 +67,15 @@ class Stepper {
 
   bool checkClamped();
 
-  private:
-
-    utils::Logger&        log_;
-    data::Data&           data_;
-    data::EmergencyBrakes em_brakes_data_;
-    GPIO                  command_pin_;
-    GPIO                  button_;
-    uint8_t               brake_id_;
-    uint8_t               is_clamped_;
-    uint64_t              timer;
-
+ private:
+  utils::Logger&        log_;
+  data::Data&           data_;
+  data::EmergencyBrakes em_brakes_data_;
+  GPIO                  command_pin_;
+  GPIO                  button_;
+  uint8_t               brake_id_;
+  uint8_t               is_clamped_;
+  uint64_t              timer;
 };
 
 }}  // namespace hyped::embrakes

--- a/test/Makefile
+++ b/test/Makefile
@@ -70,6 +70,9 @@ lib/libtest.a:
 lint:
 	$(Verb) python2.7 $(LINT) --workspace=test/src
 
+cleanlint:
+	$(Verb) rm -f .cpplint-cache
+
 clean:
 	$(Verb) rm -rf $(OBJS_DIR)/*
 	$(Verb) rm -f $(TARGET)

--- a/test/src/main.test.cpp
+++ b/test/src/main.test.cpp
@@ -1,7 +1,26 @@
-#include <iostream> 
+/*
+* Author: QA team
+* Organisation: HYPED
+* Date:
+* Description:
+*
+*    Copyright 2019 HYPED
+*    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+*    except in compliance with the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software distributed under
+*    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+*    either express or implied. See the License for the specific language governing permissions and
+*    limitations under the License.
+*/
+
+#include <iostream>
 #include "gtest/gtest.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
   std::cout << "running\n";
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/test/src/state_machine/dummy.test.cpp
+++ b/test/src/state_machine/dummy.test.cpp
@@ -1,34 +1,56 @@
+/*
+* Author: QA team
+* Organisation: HYPED
+* Date:
+* Description:
+*
+*    Copyright 2019 HYPED
+*    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+*    except in compliance with the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software distributed under
+*    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+*    either express or implied. See the License for the specific language governing permissions and
+*    limitations under the License.
+*/
+
 #include "gtest/gtest.h"
 #include "utils/logger.hpp"
 #include "data/data.hpp"
 #include "state_machine/hyped-machine.hpp"
 
 using hyped::data::Data;
-void t() {
+void t()
+{
   Data& d = Data::getInstance();
 }
-TEST(dummy_test, f) {
-  //Data &d = Data::getInstance();
-  ASSERT_EQ(2,1+1);
-  // ASSERT_EQ(3,1+1);
 
+TEST(dummy_test, f)
+{
+  // Data &d = Data::getInstance();
+  ASSERT_EQ(2, 1+1);
+  // ASSERT_EQ(3,1+1);
 }
 
 struct stateMachineTest : public ::testing::Test {
-  protected:
-    hyped::utils::Logger _log;
-    hyped::data::StateMachine _sm;
-    Data *_d;
-    void SetUp() {
-      _d = &Data::getInstance(); 
-      _sm = _d->getStateMachineData();
-    }
-    void TearDown() {}
+ protected:
+  hyped::utils::Logger _log;
+  hyped::data::StateMachine _sm;
+  Data *_d;
+  void SetUp()
+  {
+    _d = &Data::getInstance();
+    _sm = _d->getStateMachineData();
+  }
+  void TearDown() {}
 };
-//Test fixture for 'accelerating' state
-TEST_F(stateMachineTest, state_machine_init) {
+
+// Test fixture for 'accelerating' state
+TEST_F(stateMachineTest, state_machine_init)
+{
   _sm.current_state = hyped::data::State::kAccelerating;
   _d->setStateMachineData(_sm);
   ASSERT_EQ(_d->getStateMachineData().current_state, hyped::data::State::kAccelerating);
 }
-


### PR DESCRIPTION
## Description
All current linter errors are fixed so that CI testing can include running linter on the whole repo (telemetry still excluded)

 [Fix Linter task](https://app.clickup.com/t/2cm624)

## Changes
- Linter fix in `embrakes/`
- Linter fix in `test/`
- Change `Makefiles` linter targets