### PR TITLE
Consider warnings as error, fix all warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 compiler: gcc
-os: linux
+os:
+  - linux
+  - osx
 before_install:
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"

--- a/src/embrakes/stepper.cpp
+++ b/src/embrakes/stepper.cpp
@@ -24,10 +24,10 @@ namespace embrakes {
 Stepper::Stepper(uint8_t enable_pin, uint8_t button_pin, Logger& log, uint8_t id)
     : log_(log),
       data_(data::Data::getInstance()),
-      brake_id_(id),
       em_brakes_data_(data_.getEmergencyBrakesData()),
       command_pin_(enable_pin, utils::io::gpio::kOut, log_),
       button_(button_pin, utils::io::gpio::kIn, log_),
+      brake_id_(id),
       is_clamped_(true)
 {
   GPIO command_pin_(enable_pin, utils::io::gpio::kOut, log_);

--- a/src/utils/system.cpp
+++ b/src/utils/system.cpp
@@ -205,7 +205,7 @@ System::System(int argc, char* argv[])
         else        verbose_embrakes = true;
         break;
       case 'C':
-        strncpy(config_file, optarg, 250);
+        strncpy(config_file, optarg, 250-1);
         break;
       case 'e':   // debug_motor
         if (optarg) debug_motor = atoi(optarg);

--- a/test/src/state_machine/dummy.test.cpp
+++ b/test/src/state_machine/dummy.test.cpp
@@ -24,7 +24,7 @@
 using hyped::data::Data;
 void t()
 {
-  Data& d = Data::getInstance();
+  // Data& d = Data::getInstance();
 }
 
 TEST(dummy_test, f)

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -1,4 +1,4 @@
-CFLAGS:=-pthread -O2 -Wall -Wno-unused-result -Werror
+CFLAGS:=-pthread -O2 -Wall
 LFLAGS:=-lpthread -pthread
 
 CC:="g++"

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -1,4 +1,4 @@
-CFLAGS:=-pthread -O2 -Wall -Wno-unused-result 
+CFLAGS:=-pthread -O2 -Wall -Wno-unused-result -Werror
 LFLAGS:=-lpthread -pthread
 
 CC:="g++"


### PR DESCRIPTION
## Description
We want to compile without any warnings. This PR fixes all current compilation warnings and adds a compiler flag that treats warnings as error to fail future compilations with any warnings.
