### PR TITLE
Local Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ testrunner
 /utils/Lint/lintresults.txt
 /test/lib/googletest
 /test/lib/libtest.a
+/test/coverage_html
+/test/covdata
 binmain.o
-
 # Other rubbish
 .cpplint-cache
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NOLINT=0
 
 SRCS_DIR:=src
 LIBS_DIR:=lib
-OBJS_DIR:=bin/
+OBJS_DIR:=bin
 OBJS_RELEASE_DIR:=${OBJS_DIR}/release
 OBJS_DEBUG_DIR:=bin/debug
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ SRCS_DIR:=src
 LIBS_DIR:=lib
 OBJS_DIR:=bin/
 OBJS_RELEASE_DIR:=${OBJS_DIR}/release
-OBJS_DEBUG_DIR:=bin/debug
-
-COVERAGE_FLAGS:=--coverage
 
 
 include utils/config.mk

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,7 @@ LIBS_DIR:=lib
 GTEST:=$(LIBS_DIR)/googletest
 GTEST_LIB_TARGET:=$(GTEST)/build/lib/libgtest.a
 LINT:=../utils/Lint/presubmit.py
-
+COVERAGE_FLAGS=--coverage
 GOOGLE_TEST_LIBS = -lgtest -Llib/googletest/build/lib/
 
 VPATH=../src
@@ -52,12 +52,12 @@ runner: $(TARGET)
 
 $(TARGET): $(OBJS) lib/libtest.a
 	$(Echo) "Linking executable $(MAIN) into $@"
-	$(Verb) $(LL)  -o $@ $(OBJS) $(LFLAGS)
+	$(Verb) $(LL)  -o $@ $(OBJS) $(LFLAGS) $(COVERAGE_FLAGS) 
 
 $(OBJS):  $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp $(GTEST_LIB_TARGET)
 	$(Echo) "Compiling $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -I../src -Ilib/googletest/googletest/include -o $@ -c $(INC_DIR) $<
+	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) $(COVERAGE_FLAGS) -I../src -Ilib/googletest/googletest/include -o $@ -c $(INC_DIR) $<
 
 $(GTEST_LIB_TARGET): $(GTEST).tar.gz
 	$(Echo) "Building GTest Suite"

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,12 +5,10 @@
 TARGET=testrunner
 MAIN=main.test.cpp
 SRCS_DIR:=src
-OBJS_DIR:=../bin/test
 LIBS_DIR:=lib
 GTEST:=$(LIBS_DIR)/googletest
 GTEST_LIB_TARGET:=$(GTEST)/build/lib/libgtest.a
 LINT:=../utils/Lint/presubmit.py
-COVERAGE_FLAGS=--coverage
 COVERAGE_DIR:=coverage
 GOOGLE_TEST_LIBS = -lgtest -Llib/googletest/build/lib/
 
@@ -32,9 +30,9 @@ include $(SRCS_DIR)/Test.files
 SRCS := $(SRCS) $(MAIN)
 OBJS := $(SRCS:.cpp=.o)
 
-OBJS := $(patsubst %,$(OBJS_DIR)/%,$(OBJS))
+OBJS := $(patsubst %,$(OBJS_DEBUG_DIR)/%,$(OBJS))
 
-DEP_DIR := $(OBJS_DIR)
+DEP_DIR := $(OBJS_DEBUG_DIR)
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEP_DIR)/$*.d
 INC_DIR := -I$(SRCS_DIR) -I$(LIBS_DIR) -I../src/
 
@@ -55,7 +53,7 @@ $(TARGET): $(OBJS) lib/libtest.a
 	$(Echo) "Linking executable $(MAIN) into $@"
 	$(Verb) $(LL)  -o $@ $(OBJS) $(LFLAGS) $(COVERAGE_FLAGS) 
 
-$(OBJS):  $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp $(GTEST_LIB_TARGET)
+$(OBJS):  $(OBJS_DEBUG_DIR)/%.o: $(SRCS_DIR)/%.cpp $(GTEST_LIB_TARGET)
 	$(Echo) "Compiling $<"
 	$(Verb) mkdir -p $(dir $@)
 	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) $(COVERAGE_FLAGS) -I../src -Ilib/googletest/googletest/include -o $@ -c $(INC_DIR) $<
@@ -75,7 +73,7 @@ cleanlint:
 	$(Verb) rm -f .cpplint-cache
 
 clean:
-	$(Verb) rm -rf $(OBJS_DIR)/*
+	$(Verb) rm -rf $(OBJS_DEBUG_DIR)/*
 	$(Verb) rm -rf $(COVERAGE_DIR)
 	$(Verb) rm -f $(TARGET)
 	$(Verb) rm -f $(MAINS)

--- a/test/get_code_cov.sh
+++ b/test/get_code_cov.sh
@@ -1,0 +1,7 @@
+mkdir -p test/covdata
+lcov -i --directory bin -b . --capture --no-external --output-file ./test/covdata/hyped.base.covdata
+lcov --remove ./test/covdata/hyped.base.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.base.covdata
+lcov --directory bin -b . --capture --no-external --output-file ./test/covdata/hyped.test.covdata
+lcov --remove ./test/covdata/hyped.test.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.test.covdata
+lcov -a ./test/covdata/hyped.base.covdata -a ./test/covdata/hyped.test.covdata -o ./test/covdata/hyped.covdata
+genhtml --output-directory ./test/coverage_html ./test/covdata/hyped.covdata

--- a/test/get_code_cov.sh
+++ b/test/get_code_cov.sh
@@ -1,7 +1,0 @@
-mkdir -p test/covdata
-lcov -i --directory bin -b . --capture --no-external --output-file ./test/covdata/hyped.base.covdata
-lcov --remove ./test/covdata/hyped.base.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.base.covdata
-lcov --directory bin -b . --capture --no-external --output-file ./test/covdata/hyped.test.covdata
-lcov --remove ./test/covdata/hyped.test.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.test.covdata
-lcov -a ./test/covdata/hyped.base.covdata -a ./test/covdata/hyped.test.covdata -o ./test/covdata/hyped.covdata
-genhtml --output-directory ./test/coverage_html ./test/covdata/hyped.covdata

--- a/test/utils/get_code_cov.sh
+++ b/test/utils/get_code_cov.sh
@@ -1,0 +1,7 @@
+mkdir -p test/covdata
+lcov -q -i --directory  bin/debug -b . --capture --no-external --output-file ./test/covdata/hyped.base.covdata 
+lcov -q --remove ./test/covdata/hyped.base.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.base.covdata
+lcov -q --directory bin/debug -b . --capture --no-external --output-file ./test/covdata/hyped.test.covdata
+lcov -q --remove ./test/covdata/hyped.test.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/covdata/hyped.test.covdata
+lcov -q -a ./test/covdata/hyped.base.covdata -a ./test/covdata/hyped.test.covdata -o ./test/covdata/hyped.covdata
+genhtml --output-directory ./test/coverage_html ./test/covdata/hyped.covdata --quiet

--- a/test/utils/get_code_cov.sh
+++ b/test/utils/get_code_cov.sh
@@ -1,4 +1,4 @@
-if ![ lcov -v given-command > /dev/null 2>&1 ]; then
+if [ -z `which lcov` ]; then
   echo Please install lcov to calculate coverage
   exit 1
 fi

--- a/test/utils/get_code_cov.sh
+++ b/test/utils/get_code_cov.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -e
 if [ -z `which lcov` ]; then
   echo Please install lcov to calculate coverage
   exit 1

--- a/test/utils/get_code_cov.sh
+++ b/test/utils/get_code_cov.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-set -e
-if [ -z `which lcov` ]; then
-  echo Please install lcov to calculate coverage
-  exit 1
-fi
 
-if ![ genhtml -v given-command > /dev/null 2>&1 ]; then
-  echo Please install lcov to calculate coverage
-  exit 1
-fi
+set -e
+
+command -v lcov > /dev/null 2>&1 || {
+    echo >&2 "PLEASE INSTALL LCOV TO CALCULATE COVERAGE"
+    exit 1
+}
+
+command -v genhtml > /dev/null 2>&1 || {
+    echo >&2 "PLEASE INSTALL LCOV TO CALCULATE COVERAGE"
+    exit 1
+}
 
 mkdir -p test/coverage/covdata
 echo "Calculating Initial Coverage"

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -1,6 +1,7 @@
 CFLAGS:=-pthread -O2 -Wall
 LFLAGS:=-lpthread -pthread
-
+COVERAGE_FLAGS=--coverage
+OBJS_DEBUG_DIR:=bin/debug
 CC:="g++"
 UNAME=$(shell uname)
 ifneq ($(UNAME),Linux)

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -1,5 +1,5 @@
-CFLAGS:=-pthread -O2 -Wall -Wno-unused-result 
-LFLAGS:=-lpthread -pthread
+CFLAGS:=-pthread -O0 -g -Wall -Wno-unused-result 
+LFLAGS:=-lpthread -pthread --verbose
 
 CC:="g++"
 UNAME=$(shell uname)


### PR DESCRIPTION
## Description
This PR adds the functionality to run a local line coverage analysis using `lcov` and `genhtml`. We currently check the % of statements covered.

 *Click up link*: [https://app.clickup.com/t/2ecn1w](https://app.clickup.com/t/2ecn1w)

## Changes
- split bin folder into `bin/release` and `bin/debug` as coverage requires additional tooling to be added to `.o` files 
- adds `make coverage` option which build and runs the test suite and outputs coverage report

## Additional Info 
We use `genhtml` to produce a human readable version of our coverage data
> <img width="1440" alt="Screenshot 2019-11-20 at 13 16 38" src="https://user-images.githubusercontent.com/31216525/69242152-27ddc000-0b98-11ea-9556-6014852546bf.png">
> An overall view of the code coverage across the submodules, we have written a small test for the Data class.

> <img width="1439" alt="Screenshot 2019-11-20 at 13 16 44" src="https://user-images.githubusercontent.com/31216525/69242153-27ddc000-0b98-11ea-9979-638bf845f88a.png">
> Each sub directory has a per file break down of % coverage


> <img width="1430" alt="Screenshot 2019-11-20 at 13 16 56" src="https://user-images.githubusercontent.com/31216525/69242154-28765680-0b98-11ea-8dbd-27e50fe8db6b.png">
> You can see how many times a line was run at great detail! 
