### PR TITLE
Enable Code Cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  - [ "$TRAVIS_OS_NAME" = "linux" ] && bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"; fi
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"          ; fi
+  - [ "$TRAVIS_OS_NAME" = "linux" ] && bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  -  if [ "$TRAVIS_OS_NAME" = "linux" ]; bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"          ; fi
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ addons:
 before_install:
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"
-script: "CI=1 make coverage lintall "
+script: "CI=1 make testrunner lintall"
 after_success:
+  - CI=1 make coverage 
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"; fi
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 compiler: gcc
 addons:
+  homebrew:
+      packages: lcov
   apt:
     packages: lcov
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: cpp
 compiler: gcc
+addons:
+  apt:
+    packages: lcov
 os:
   - linux
   - osx
 before_install:
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"
-script: "make testrunner lintall"
+script: "CI=1 make coverage lintall "
+after_success:
+  -  bash <(curl -s https://codecov.io/bash) -f hyped.covdata || echo "Codecov did not collect coverage reports"
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  -  bash <(curl -s https://codecov.io/bash) -f test/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
+  -  bash <(curl -s https://codecov.io/bash) -f test/coverage/ovdata/hyped.covdata || echo "Codecov did not collect coverage reports"
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  -  bash <(curl -s https://codecov.io/bash) -f hyped.covdata || echo "Codecov did not collect coverage reports"
+  -  bash <(curl -s https://codecov.io/bash) -f test/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_install:
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  -  bash <(curl -s https://codecov.io/bash) -f test/coverage/ovdata/hyped.covdata || echo "Codecov did not collect coverage reports"
+  -  bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,16 @@ compiler: gcc
 os:
   - linux
   - osx
-  
+
 addons:
   apt:
     packages: lcov
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lcov; fi
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "
 after_success:
-  -  bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"
+  -  if [ "$TRAVIS_OS_NAME" = "linux" ]; bash <(curl -s https://codecov.io/bash) -f test/coverage/covdata/hyped.covdata || echo "Codecov did not collect coverage reports"; fi
 rvm:
   - 9.00

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: cpp
 compiler: gcc
-addons:
-  homebrew:
-      packages: lcov
-  apt:
-    packages: lcov
+
 os:
   - linux
   - osx
+  
+addons:
+  apt:
+    packages: lcov
+
 before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lcov; fi
   - cd test && sudo chmod u+x setup.sh && ./setup.sh
   - cd "${TRAVIS_BUILD_DIR}"
 script: "CI=1 make coverage lintall "

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![HYPED Logo](https://lh3.googleusercontent.com/vc_gTpaMWBdv0dCl0ufjHWQWuUcF56tLGsDHL3VFVRisD_nD3nZEP99M8YS1TkOP0Xbmei8e1F4HYojjmQxg3HOwExLMKuu6DT8T6T_LzIVztkPm7ljoNxWqptyLusi5IB78e9FpRF_3xekEZNvcKaDUP-ZTRfEbVu70As4FnEST9RDDbVPoXyCQcJQbzee-qCiCPqi2URFzUs_7C-QWtw-nOhMTw2M7A_P8wItXe7ExvctySQsAmRL_9udvqOVc45bqx3lSPyPBc3AKr2yH8vwfwMZTy7cbPoroqkWgNoQJCketb4wU_eR2t4ezRNNX9SHumFsC-MFRjnT_uOYukEFAbmTlOISrtqm1rOUhS72pCZLnWxucvxrkMwMWEVYHWx4FfpaMttH7F9glao82PfaZh5SMzliXrnSzW1YEH6eMZwjI2N4_3qBrQs0ig6epldHvy1OIbjKsBBMPGnb1qPFYsvJFA3BmagtPPmPhdQvFcLTxE8QiKGxSm-GAMTdoewhgyyXNawu1bS35BHFT4aLtBn4N8Uv-OA0__mdtPqs04ZV08953T_XijKxKItLzpQRjkavMqagzCAGPv2xLUH2g-hD6OplvWxMnN8o7T65tJONd-kD2-6f8cw=w2880-h1530)
 
 [![Build Status](https://travis-ci.org/Hyp-ed/hyped-2020.svg?branch=develop)](https://travis-ci.org/Hyp-ed/hyped-2020)
+[![Coverage Status](https://codecov.io/gh/hyp-ed/hyped-2020/branch/develop/graph/badge.svg)](https://codecov.io/gh/hyp-ed/hyped-2020)
+
 
 This is the official repository of HYPED. HYPED is a student society at the University of Edinburgh dedicated to accelerating the development of Hyperloop and implementing the technology in the UK. HYPED is advancing both technical and commercial development of Hyperloop, having seen success in two international competitions. https://hyp-ed.com/
 

--- a/test/utils/get_code_cov.sh
+++ b/test/utils/get_code_cov.sh
@@ -21,6 +21,9 @@ lcov -q --directory bin/debug -b . --capture --no-external --output-file ./test/
 lcov -q --remove ./test/coverage/covdata/hyped.test.covdata `pwd`/lib/\* `pwd`/\*.test.cpp -o ./test/coverage/covdata/hyped.test.covdata
 echo "Combining Coverage Stats"
 lcov -q -a ./test/coverage/covdata/hyped.base.covdata -a ./test/coverage/covdata/hyped.test.covdata -o ./test/coverage/covdata/hyped.covdata
-echo "Generating HTML Report"s
-genhtml --output-directory ./test/coverage/coverage_html ./test/coverage/covdata/hyped.covdata --quiet
-echo "HTML Report saved at test/coverage/coverage_html"
+if [ -z $CI ];
+then
+  echo "Generating HTML Report"
+  genhtml --output-directory ./test/coverage/coverage_html ./test/coverage/covdata/hyped.covdata --quiet
+  echo "HTML Report saved at test/coverage/coverage_html"
+fi


### PR DESCRIPTION
## Description
This PR adds CodeCov as a hosted coverage viewer, this will allow people to see the code coverage without having to install tooling on their machine.

As you can seee below, CodeCov will provide a coverage report on each PR.

 *Click up link* [https://app.clickup.com/t/2ecn2p](https://app.clickup.com/t/2ecn2p)

## Changes
- add code cov to `after_success`
- remove `genhtml` step if env var `CI` is 1
- add code cov badge to readme

## Additional Info 
N/A