### PR TITLE
Fix Makefile build release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,13 @@ else
 	$(Verb) $(CC) $(DEPFLAGS_RELEASE) $(CFLAGS) -o $@ -c $(INC_DIR) $<
 endif
 
-$(OBJS): $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp $(DEPENDENCIES)
+$(OBJS): $(OBJS_RELEASE_DIR)/%.o: $(SRCS_DIR)/%.cpp $(DEPENDENCIES)
 	$(Echo) "Compiling $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS_RELEASE) $(CFLAGS) -o $@ -c $(INC_DIR) $< 
+	$(Verb) $(CC) $(DEPFLAGS_RELEASE) $(CFLAGS) -o $@ -c $(INC_DIR) $<
 
 
-$(TEST_OBJS): $(OBJS_DEBUG_DIR)/%.o: $(SRCS_DIR)/%.cpp
+$(TEST_OBJS): $(OBJS_DEBUG_DIR)/%.o: $(SRCS_DIR)/%.cpp $(DEPENDENCIES)
 		$(Echo) "Compiling $<"
 		$(Verb) mkdir -p $(dir $@)
 		$(Verb) $(CC) $(DEPFLAGS_DEBUG) $(CFLAGS) -o $@ -c $(INC_DIR) $< ${COVERAGE_FLAGS}


### PR DESCRIPTION
## Description
Just `make`ing the project did not work due to release object fine not correctly resolving to the `.cpp` dependencies in the main `Makefile`