### PR TITLE
Check for Python Before Running Linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 TARGET=hyped
 MAIN=run/main.cpp
 CROSS=0
-NOLINT=0
 
 #pass this option to run static checker with specified severity
 # e.g. make static STATIC_ENABLE=style
@@ -95,18 +94,23 @@ $(TEST_OBJS): $(OBJS_DEBUG_DIR)/%.o: $(SRCS_DIR)/%.cpp $(DEPENDENCIES)
 		$(Verb) mkdir -p $(dir $@)
 		$(Verb) $(CC) $(DEPFLAGS_DEBUG) $(CFLAGS) -o $@ -c $(INC_DIR) $< ${COVERAGE_FLAGS}
 lint:
-ifeq ($(NOLINT), 0)
+ifeq ($(RUNLINTER), 1)
 	$(Verb) python2.7 utils/Lint/presubmit.py --workspace=src
+else
+	$(Echo) "Linting skipped, if linting has not been manually disabled, please check your python installation"
 endif
 
 lintall:
+ifeq ($(RUNLINTER), 1)
 	$(Echo) "\nLinting src/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=src
 	$(Echo) "\nLinting run/"
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=run
 	$(Echo) "\nLinting test/"
 	$(Verb) $(MAKE) -C test lint --no-print-directory
-
+else
+	$(Echo) "Linting skipped, if linting has not been manually disabled, please check your python installation"
+endif
 static:
 	$(Verb) $(MAKE) -C test staticcheck CPPCHECK_ENABLE_OPS=$(STATIC_ENABLE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # define VERBOSE to see executed commands
 # default build configuration
 TARGET=hyped
@@ -108,8 +107,8 @@ ifeq ($(RUNLINTER), 1)
 	$(Verb) -python2.7 utils/Lint/presubmit.py --workspace=run
 	$(Echo) "\nLinting test/"
 	$(Verb) $(MAKE) -C test lint --no-print-directory
-else
-	$(Echo) "Linting skipped, if linting has not been manually disabled, please check your python installation"
+else ifeq ($(PYTHONCHECK), 0)
+	$(Echo) $(error Check Python Version >=2.7 installed!)
 endif
 static:
 	$(Verb) $(MAKE) -C test staticcheck CPPCHECK_ENABLE_OPS=$(STATIC_ENABLE)

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ $(TEST_OBJS): $(OBJS_DEBUG_DIR)/%.o: $(SRCS_DIR)/%.cpp $(DEPENDENCIES)
 lint:
 ifeq ($(RUNLINTER), 1)
 	$(Verb) python2.7 utils/Lint/presubmit.py --workspace=src
-else
-	$(Echo) "Linting skipped, if linting has not been manually disabled, please check your python installation"
+else ifeq ($(PYTHONCHECK), 0)
+	$(error Cannot find Python 2.7, please check Python Version >=2.7  is installed )
 endif
 
 lintall:
@@ -108,7 +108,7 @@ ifeq ($(RUNLINTER), 1)
 	$(Echo) "\nLinting test/"
 	$(Verb) $(MAKE) -C test lint --no-print-directory
 else ifeq ($(PYTHONCHECK), 0)
-	$(Echo) $(error Check Python Version >=2.7 installed!)
+	$(error Cannot find Python 2.7, please check Python Version >=2.7  is installed )
 endif
 static:
 	$(Verb) $(MAKE) -C test staticcheck CPPCHECK_ENABLE_OPS=$(STATIC_ENABLE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -94,6 +94,8 @@ lib/libtest.a:
 lint:
 ifeq ($(RUNLINTER), 1)
 	$(Verb) python2.7 $(LINT) --workspace=test/src
+else ifeq ($(PYTHONCHECK), 0)
+	$(error Cannot find Python 2.7, please check Python Version >=2.7  is installed )
 endif
 cleanlint:
 	$(Verb) rm -f .cpplint-cache

--- a/test/Makefile
+++ b/test/Makefile
@@ -92,8 +92,9 @@ lib/libtest.a:
 	$(Verb) make -C .. test/lib/libtest.a
 
 lint:
+ifeq ($(RUNLINTER), 1)
 	$(Verb) python2.7 $(LINT) --workspace=test/src
-
+endif
 cleanlint:
 	$(Verb) rm -f .cpplint-cache
 

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -19,8 +19,13 @@ ROOT=$(shell git rev-parse --show-toplevel)
 PYTHON=$(shell python2.7 -V  >/dev/null 2>&1 && echo "1" )
 
 PYTHONCHECK=$(shell [[ -z "$(PYTHON)" ]] && echo "0" || echo "1")
+
 # Manual override for LINTER
-NOLINT=0
+# run "make VERBOSE=1" to see all commands
+ifndef NOLINT
+	NOLINT := 0
+endif
+
 
 # Checks manual override and python flag defined in config
 RUNLINTER=$(shell [[ $(NOLINT) == 0 && $(PYTHONCHECK) == 1 ]] && echo 1 )

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -13,3 +13,12 @@ else
 endif
 
 ROOT=$(shell git rev-parse --show-toplevel)
+
+## Is 1 when python is installed
+PYTHONCHECK=$(shell python2.7 -V  >/dev/null 2>&1 | grep -q 'Python 2.7(.[0-9]+)*'  | echo '1' )
+
+# Manual override for LINTER
+NOLINT=0
+
+# Checks manual override and python flag defined in config
+RUNLINTER=$(shell [[ $(NOLINT) == 0 && $(PYTHONCHECK) == 1 ]] && echo 1 )

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -2,6 +2,7 @@ CFLAGS:=-pthread -O2 -Wall
 LFLAGS:=-lpthread -pthread
 COVERAGE_FLAGS=--coverage
 OBJS_DEBUG_DIR:=bin/debug
+SHELL:=/bin/bash
 CC:="g++"
 UNAME=$(shell uname)
 ifneq ($(UNAME),Linux)

--- a/utils/config.mk
+++ b/utils/config.mk
@@ -16,8 +16,9 @@ endif
 ROOT=$(shell git rev-parse --show-toplevel)
 
 ## Is 1 when python is installed
-PYTHONCHECK=$(shell python2.7 -V  >/dev/null 2>&1 | grep -q 'Python 2.7(.[0-9]+)*'  | echo '1' )
+PYTHON=$(shell python2.7 -V  >/dev/null 2>&1 && echo "1" )
 
+PYTHONCHECK=$(shell [[ -z "$(PYTHON)" ]] && echo "0" || echo "1")
 # Manual override for LINTER
 NOLINT=0
 


### PR DESCRIPTION
## Description
This adds a check to the make file which will not run the linter if Python is not installed 

If not installed gracefully handles error:
```bash
root@5291d11379ff:~/hyped-2020# make lintall
Makefile:111: *** Cannot find Python 2.7, please check Python Version >=2.7  is installed .  Stop.
```
 *Click up link* [https://app.clickup.com/t/3amn5t](https://app.clickup.com/t/3amn5t)

## Changes
- Added a PYTHONCHECK variable which combines with NOLINT to figure out whether to run the linter or not 

## Additional Info 
Tested using Ubuntu Container without Python2.7 