### PR TITLE
Fix setup.sh not working when hyped-2020 is a submodule

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,11 +5,11 @@ echo -n "Deploying git hooks: "
 
 HOOKDIR=.git/hooks
 
-# when repo is a subrepo, .git is a file describing the path to the actual gitdir
-if [ -f .git ]
+# when repo is a subrepo, .git is not a directory, but a file describing the path to the actual gitdir
+if [ ! -d .git ]
 then
-    # reroute $HOOKDIR to the actual directory
-    HOOKDIR=$(perl -nle 'print $1 if /gitdir: (.+)/' .git)
+    echo "IGNORING SINCE SUBMODULE"
+    exit
 fi
 
 # remove old hooks

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,15 @@
 set -e
 
 echo -n "Deploying git hooks: "
+
 HOOKDIR=.git/hooks
+
+# when repo is a subrepo, .git is a file describing the path to the actual gitdir
+if [ -f .git ]
+then
+    # reroute $HOOKDIR to the actual directory
+    HOOKDIR=$(perl -nle 'print $1 if /gitdir: (.+)/' .git)
+fi
 
 # remove old hooks
 rm -rf $HOOKDIR
@@ -10,7 +18,7 @@ mkdir -p $HOOKDIR
 
 # copy new hooks, make executable
 cp utils/githooks/* $HOOKDIR/
-for file in .git/hooks/*
+for file in $HOOKDIR/*
 do
   chmod u+x $file
 done


### PR DESCRIPTION
When hyped-2020 is cloned as a submodule, .git is not a folder but a file pointing to the git-folder, which is located elsewhere

## Description
When this repo is initialised as a submodule and `./setup.sh` is run, the error message `Deploying git hooks: rm: .git/hooks: Not a directory` is emitted because .git is not a folder but instead a file:
`
gitdir: ../.git/modules/hyped-pod_code/
`.

To handle this, setup.sh now updates `$HOOKDIR` to point to the actual directory in case .git is a file.