### PR TITLE
Rename functions in Config and Interfaces for better readability

### DIFF
--- a/run/factory.cpp
+++ b/run/factory.cpp
@@ -31,9 +31,9 @@ int main(int argc, char* argv[])
   utils::System::parseArgs(argc, argv);
   utils::System& sys = utils::System::getSystem();
 
-  sensors::ImuInterface* imu = sys.config->interfaceFactory.getImuInterface();
+  sensors::ImuInterface* imu = sys.config->interfaceFactory.getImuInterfaceInstance();
 
-  demo::DemoInterface* demo = sys.config->interfaceFactory.getDemoInterface();
+  demo::DemoInterface* demo = sys.config->interfaceFactory.getDemoInterfaceInstance();
   demo->printYourName();
 
   return 0;

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -216,7 +216,8 @@ void Config::parseInterfaceFactory(char* line)
 #define PARSE_FACTORY(module, interface)                                            \
   if (strcmp(key, #interface) == 0) {                                               \
     auto creator = utils::InterfaceFactory<module::interface>::getCreator(value);            \
-    interfaceFactory.get##interface = creator ? creator : createDefault<module::interface>;  \
+    interfaceFactory.get##interface##Instance = creator ? creator :  \
+      createDefault<module::interface>;  \
     return;                                                                         \
   }
   INTERFACE_LIST(PARSE_FACTORY)
@@ -321,7 +322,7 @@ Config::Config(char* config_file)
     : log_(System::getLogger())
 {
 #define INIT_CREATOR(module, interface) \
-  interfaceFactory.get##interface = createDefault<module::interface>;
+  interfaceFactory.get##interface##Instance = createDefault<module::interface>;
   INTERFACE_LIST(INIT_CREATOR)
 
   config_files_.push_back(config_file);

--- a/src/utils/config.hpp
+++ b/src/utils/config.hpp
@@ -104,7 +104,7 @@ class Config {
   struct InterfaceFactory {
   // Module used in this context refers to the namespace containing the interface.
 #define CREATOR_FUNCTION_POINTERS(module, interface) \
-  module::interface* (*get##interface)();
+  module::interface* (*get##interface##Instance)();
   INTERFACE_LIST(CREATOR_FUNCTION_POINTERS)
   } interfaceFactory;
 

--- a/src/utils/interfaces.hpp
+++ b/src/utils/interfaces.hpp
@@ -36,9 +36,9 @@
 
 // use format V(module/namespace, class)
 // e.g.       V(utils::config::fancy::typed::here, MyFancyInterface)
-#define INTERFACE_LIST(V) \
-  V(sensors, ImuInterface) \
-  V(demo, DemoInterface)
+#define INTERFACE_LIST(Register) \
+  Register(sensors, ImuInterface) \
+  Register(demo, DemoInterface)
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/interfaces.hpp
+++ b/src/utils/interfaces.hpp
@@ -34,11 +34,11 @@
  * class name, not the full namespaced name.
  */
 
-// use format V(module/namespace, class)
-// e.g.       V(utils::config::fancy::typed::here, MyFancyInterface)
-#define INTERFACE_LIST(Register) \
-  Register(sensors, ImuInterface) \
-  Register(demo, DemoInterface)
+// use format REGISTER(module/namespace, class)
+// e.g.       REGISTER(utils::config::fancy::typed::here, MyFancyInterface)
+#define INTERFACE_LIST(REGISTER) \
+  REGISTER(sensors, ImuInterface) \
+  REGISTER(demo, DemoInterface)
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
Renaming of functions and macro argument in the interfaces.hpp, config.hpp and config.cpp files, in order to improve readability.
