### PR TITLE
Add support to generate compilation database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ lib/rapidjson
 # mac crosscompiler
 mac-crosscompiler
 mac-crosscompiler/
+
+# clangd indices
+.clangd/
+
+# compilation database
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,13 @@ else ifeq ($(PYTHONCHECK), 0)
 	$(error Cannot find Python 2.7, please check Python Version 2.7.X  is installed )
 endif
 
-clean-all: clean clean-lint test-clean
+clean-all: clean clean-lint clean-compiledb test-clean
 
 clean-lint:
 	$(Verb) rm -f .cpplint-cache
+
+clean-compiledb:
+	$(Verb) rm -f compile_commands.json
 
 clean:
 	$(Verb) rm -rf $(OBJS_DIR)/
@@ -69,8 +72,13 @@ info:
 	$(call echo_var,UNAME)
 	$(call echo_var,CFLAGS)
 
+# This finds all the individual compilation database files in the bin directory, and
+# combines them into one compile_commands.json file
+# Only works with gnu sed, couldn't get newlines to work with bsd sed
+# On mac use homebrew to install gnu sed
+# Double $ signs are so Make interprets it as a single regex $, on command line use one $
 gen-compilation-db:
-	$(Verb) find bin -name '*.json' | xargs sed -e '1s/^/[\n/' -e '$s/,$/\n]/' > compile_commands.json
+	$(Verb) find bin -name '*.json' -exec sed -e '1s/^/[\n/' -e '$$s/,$$/\n]/' {} + > compile_commands.json
 
 # PHONY to redo even if .ccls file exists
 .PHONY: .ccls

--- a/Makefile
+++ b/Makefile
@@ -41,17 +41,15 @@ else ifeq ($(PYTHONCHECK), 0)
 	$(error Cannot find Python 2.7, please check Python Version 2.7.X  is installed )
 endif
 
-clean-all: clean clean-lint clean-compiledb test-clean
+clean-all: clean clean-lint test-clean
 
 clean-lint:
 	$(Verb) rm -f .cpplint-cache
 
-clean-compiledb:
-	$(Verb) rm -f compile_commands.json
-
 clean:
 	$(Verb) rm -rf $(OBJS_DIR)/
 	$(Verb) rm -f $(TARGET)
+	$(Verb) rm -f compile_commands.json
 
 define echo_var
   @echo $(1) = $($1)
@@ -71,14 +69,6 @@ info:
 	$(call echo_var,OBJS)
 	$(call echo_var,UNAME)
 	$(call echo_var,CFLAGS)
-
-# This finds all the individual compilation database files in the bin directory, and
-# combines them into one compile_commands.json file
-# Only works with gnu sed, couldn't get newlines to work with bsd sed
-# On mac use homebrew to install gnu sed
-# Double $ signs are so Make interprets it as a single regex $, on command line use one $
-gen-compilation-db:
-	$(Verb) find bin -name '*.json' -exec sed -e '1s/^/[\n/' -e '$$s/,$$/\n]/' {} + > compile_commands.json
 
 # PHONY to redo even if .ccls file exists
 .PHONY: .ccls

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ info:
 	$(call echo_var,UNAME)
 	$(call echo_var,CFLAGS)
 
+gen-compilation-db:
+	$(Verb) find bin -name '*.json' | xargs sed -e '1s/^/[\n/' -e '$s/,$/\n]/' > compile_commands.json
+
 # PHONY to redo even if .ccls file exists
 .PHONY: .ccls
 .ccls:

--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -70,6 +70,14 @@ MAIN_OBJ  := $(patsubst run/%.cpp, $(OBJS_DIR)/%.o, $(MAIN))
 $(TARGET): $(DEPENDENCIES) $(OBJS) $(MAIN_OBJ)
 	$(Echo) "Linking executable $(MAIN) into $@"
 	$(Verb) $(LL)  -o $@ $(OBJS) $(MAIN_OBJ) $(LFLAGS) $(COVERAGE_FLAGS)
+ifneq ($(shell $(CC) --version 2>&1 | grep -c "clang"), 0)
+# This finds all the individual compilation database files in the bin directory if using clang,
+# and combines them into one compile_commands.json file
+# Only works with gnu sed, couldn't get newlines to work with bsd sed
+# On mac use homebrew to install gnu sed
+# Double $ signs are so Make interprets it as a single regex $, on command line use a single $ sign
+	$(Verb) find bin -name '*.json' -exec sed -e '1s/^/[\n/' -e '$$s/,$$/\n]/' {} + > compile_commands.json
+endif
 
 $(MAIN_OBJ): $(OBJS_DIR)/%.o: $(MAIN)
 	$(Echo) "Compiling main: $<"

--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -55,8 +55,11 @@ ifeq ($(shell which $(CC)), )
 	$(warning compiler $(CC) is not installed)
 endif
 
+# detect if clang is being used as compiler
+USING_CLANG := $(shell $(CC) --version 2>&1 | grep -c "clang")
+
 # only use -MJ flag to generate compilation database if using clang
-ifneq ($(shell $(CC) --version 2>&1 | grep -c "clang"), 0)
+ifeq ($(USING_CLANG), 1)
 	COMPILATION_DB = -MJ $(addsuffix .json, $@)
 endif
 
@@ -70,8 +73,8 @@ MAIN_OBJ  := $(patsubst run/%.cpp, $(OBJS_DIR)/%.o, $(MAIN))
 $(TARGET): $(DEPENDENCIES) $(OBJS) $(MAIN_OBJ)
 	$(Echo) "Linking executable $(MAIN) into $@"
 	$(Verb) $(LL)  -o $@ $(OBJS) $(MAIN_OBJ) $(LFLAGS) $(COVERAGE_FLAGS)
-ifneq ($(shell $(CC) --version 2>&1 | grep -c "clang"), 0)
-# This finds all the individual compilation database files in the bin directory if using clang,
+ifeq ($(USING_CLANG), 1)
+# This finds all the individual compilation database files in the bin directory,
 # and combines them into one compile_commands.json file
 # Only works with gnu sed, couldn't get newlines to work with bsd sed
 # On mac use homebrew to install gnu sed

--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -69,9 +69,9 @@ $(TARGET): $(DEPENDENCIES) $(OBJS) $(MAIN_OBJ)
 $(MAIN_OBJ): $(OBJS_DIR)/%.o: $(MAIN)
 	$(Echo) "Compiling main: $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
+	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -MJ $(addsuffix .json, $@) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
 
 $(OBJS): $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp
 	$(Echo) "Compiling $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
+	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -MJ $(addsuffix .json, $@) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)

--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -55,6 +55,11 @@ ifeq ($(shell which $(CC)), )
 	$(warning compiler $(CC) is not installed)
 endif
 
+# only use -MJ flag to generate compilation database if using clang
+ifneq ($(shell $(CC) --version 2>&1 | grep -c "clang"), 0)
+	COMPILATION_DB = -MJ $(addsuffix .json, $@)
+endif
+
 LL := $(CC)
 
 # auto-discover all sources
@@ -69,9 +74,9 @@ $(TARGET): $(DEPENDENCIES) $(OBJS) $(MAIN_OBJ)
 $(MAIN_OBJ): $(OBJS_DIR)/%.o: $(MAIN)
 	$(Echo) "Compiling main: $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -MJ $(addsuffix .json, $@) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
+	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) $(COMPILATION_DB) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
 
 $(OBJS): $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp
 	$(Echo) "Compiling $<"
 	$(Verb) mkdir -p $(dir $@)
-	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) -MJ $(addsuffix .json, $@) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)
+	$(Verb) $(CC) $(DEPFLAGS) $(CFLAGS) $(COMPILATION_DB) -o $@ -c $(INC_DIR) $< $(COVERAGE_FLAGS)


### PR DESCRIPTION
## Description
Generates a `compile_commands.json` compilation database, used for semantic auto-complete in text editors using the `clangd` language server. Can be used for text editors that support the language server protocol, like VSCode and Vim :))

https://sarcasm.github.io/notes/dev/compilation-database.html