### PR TITLE
Use new crosscompiler

### DIFF
--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -39,7 +39,7 @@ ifeq ($(CROSS), 1)
 	LFLAGS := $(LFLAGS) --target=arm-linux-gnueabihf -L$(COMPILER_PATH) --sysroot=mac-crosscompiler/sysroot
   else
     $(info cross-compiling using Linux host)
-	CC := hyped-cross-g++
+	CC := arm-linux-gnueabihf-g++
 	LFLAGS := $(LFLAGS) -static
   endif
 else

--- a/utils/build/build.mk
+++ b/utils/build/build.mk
@@ -52,7 +52,7 @@ CFLAGS += -DARCH_$(ARCH)
 
 # test if compiler is installed
 ifeq ($(shell which $(CC)), )
-	$(warning compiler $(CC) is not installed)
+    $(error Compiler $(CC) is not installed)
 endif
 
 LL := $(CC)


### PR DESCRIPTION
## Description
Simplify the crosscompiler setup.

For comparison, [here](https://github.com/Hyp-ed/hyped-2019/blob/develop/docs/guides/linux_cross_compile.md#linux-cross-compile) are the old instructions for setting up the crosscompiler and [here](https://github.com/Hyp-ed/hyped-2020/wiki/Linux-crosscompiler-for-the-BBB) are the new ones (1 step instead of 6). These changes are backwards compatible with the old guide in case someone still had that setup.

**Note:** There is a small chance that this approach might be less reliable as the crosscompiler in apt repositories will receive updates. If there are ever some weird issues where it doesn't work for some people, it might be a good idea to check the crosscompiler versions (`arm-linux-gnueabihf-g++ --version`). I tried 2 versions, both different from the old crosscompiler, and they worked fine.

## Changes
- Rename the crosscompiler so a HYPED alias is not necessary. (Also seems to somehow make the output colourful like with normal compiler.)
- Fix indentation in the makefile to produce the proper error when a (cross)compiler is not installed.
